### PR TITLE
Fix unneeded warning from brew

### DIFF
--- a/Formula/src-cli.rb
+++ b/Formula/src-cli.rb
@@ -6,7 +6,6 @@ class SrcCli < Formula
   desc "Sourcegraph CLI"
   homepage "https://sourcegraph.com/"
   version "3.33.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.arm?


### PR DESCRIPTION
Should help fix the following warning

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the sourcegraph/src-cli tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/sourcegraph/homebrew-src-cli/Formula/src-cli.rb:9
```